### PR TITLE
Replace News Option with Social Media in Form Content

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       <label for="referrer">Como nos conheceu?
         <select id="referrer" name="hearUsr">
           <option value="">(Selecione)</option>
-          <option value="1">Notícias'</option>
+          <option value="1">Redes Sociais</option>
           <option value="2">Canal do YouTube</option>
           <option value="3">Indicação</option>
           <option value="4">Outros</option>


### PR DESCRIPTION
The change aims to remove the news option and replace it with social media, as it better corresponds to the form's content.